### PR TITLE
Throw CException on error

### DIFF
--- a/Pdfable.php
+++ b/Pdfable.php
@@ -207,8 +207,6 @@ class Pdfable extends CBehavior
         if(!$pdf->send($filename))
         {
             throw new CException("Could not create PDF for view $view" . (YII_DEBUG ? "\n\n" . $pdf->getError() : ''));
-            Yii::log("Could not create PDF for view $view",'error','ext.pdfable.Pdfable');
-            YII_DEBUG && Yii::trace($pdf->getError(), 'ext.pdfable.Pdfable');
         }
     }
 

--- a/Pdfable.php
+++ b/Pdfable.php
@@ -206,6 +206,7 @@ class Pdfable extends CBehavior
 
         if(!$pdf->send($filename))
         {
+            throw new CException("Could not create PDF for view $view" . (YII_DEBUG ? "\n\n" . $pdf->getError() : ''));
             Yii::log("Could not create PDF for view $view",'error','ext.pdfable.Pdfable');
             YII_DEBUG && Yii::trace($pdf->getError(), 'ext.pdfable.Pdfable');
         }


### PR DESCRIPTION
The current version throws a white page when it's wkhtmlpdf binary returns an error. This is confusing to end users and developers. I suggest the following change:

Throw CException when not able to generate PDF. When YII_DEBUG enabled, includes command error details.